### PR TITLE
initial commit of packagecloud client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2015, Tim Heckman
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of linode-netint nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packagecloud.go
+++ b/packagecloud.go
@@ -1,0 +1,57 @@
+package packagecloud
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Version is WISOTT.
+const Version = "0.0.1"
+
+// Client is the type for the PackageCloud API client. It has functio methods
+// for interacting with the PackageCloud API.
+type Client struct {
+	token string
+}
+
+// Config is the type for the PackageCloud client configuration.
+type Config struct {
+	// API Token for use with the PackageCloud API
+	Token string
+}
+
+func (c *Client) String() string {
+	var token string
+
+	if len(c.token) > 0 {
+		token = fmt.Sprintf("%s...%s", c.token[0:3], c.token[len(c.token)-4:])
+	}
+
+	return fmt.Sprintf(
+		"[*packagecloud.Client:<token:%s>]",
+		token,
+	)
+}
+
+// NewClient is a function for building a PacakgeCloud *Client instance. If the
+// PACKAGECLOUD_TOKEN environment value is set the *Config struct can be nil.
+func NewClient(cfg *Config) (*Client, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	if cfg.Token == "" {
+		cfg.Token = os.Getenv("PACKAGECLOUD_TOKEN")
+
+		if cfg.Token == "" {
+			return nil, errors.New("a *Config must be provided with a token or set the PACKAGECLOUD_TOKEN environment variable")
+		}
+	}
+
+	c := &Client{
+		token: cfg.Token,
+	}
+
+	return c, nil
+}

--- a/packagecloud_test.go
+++ b/packagecloud_test.go
@@ -1,0 +1,66 @@
+package packagecloud
+
+import (
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct {
+	token string
+}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) SetUpSuite(c *C) {
+	t.token = "abc123token"
+}
+
+func (t *TestSuite) TearDownTest(c *C) {
+	os.Unsetenv("PACKAGECLOUD_TOKEN")
+}
+
+func (t *TestSuite) TestNewClient(c *C) {
+	var cl *Client
+	var err error
+
+	//
+	// test that no token fails
+	//
+	cl, err = NewClient(nil)
+	c.Assert(err, Not(IsNil))
+	c.Check(cl, IsNil)
+	c.Check(err.Error(), Equals, "a *Config must be provided with a token or set the PACKAGECLOUD_TOKEN environment variable")
+
+	//
+	// test that setting a config token works
+	//
+	cl, err = NewClient(&Config{Token: t.token})
+	c.Assert(cl, Not(IsNil))
+	c.Check(err, IsNil)
+	c.Check(cl.token, Equals, "abc123token")
+
+	//
+	// test that setting a PACKAGECLOUD_TOKEN environment variable works
+	//
+	os.Setenv("PACKAGECLOUD_TOKEN", t.token)
+	cl, err = NewClient(nil)
+	c.Assert(cl, Not(IsNil))
+	c.Check(err, IsNil)
+	c.Check(cl.token, Equals, "abc123token")
+}
+
+func (t *TestSuite) TestString(c *C) {
+	var cl *Client
+	var err error
+
+	//
+	// test that the String() output is correct
+	//
+	cl, err = NewClient(&Config{Token: t.token})
+	c.Assert(err, IsNil)
+	c.Check(cl.String(), Equals, "[*packagecloud.Client:<token:abc...oken>]")
+}


### PR DESCRIPTION
This adds the initial commit of the packagecloud client. There are also some bare minimum tests in here as well.