### PR TITLE
add support for the licenses API resource

### DIFF
--- a/licenses.go
+++ b/licenses.go
@@ -1,0 +1,40 @@
+package packagecloud
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidKey is an error for when the key provided in the config is
+// invalid.
+var ErrInvalidKey = errors.New("invalid key, must be non-zero in length")
+
+// License is a struct which contains the unmarshaled data from a License request.
+type License struct {
+	License   string `json:"license"`
+	Signature string `json:"signature"`
+}
+
+// Licenses is a function to retreive a packagecloud:enterprise license file
+// and GPG signature. Signature can be verified with the packagecloud
+// GPG key: https://packagecloud.io/gpg.key.
+func (c *Client) Licenses(key string) (*License, error) {
+	if len(key) == 0 {
+		return nil, ErrInvalidKey
+	}
+
+	path := fmt.Sprintf("licenses/%s/licenses.json", key)
+
+	b, err := c.request("GET", path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	l := &License{}
+
+	err = json.Unmarshal(b, l)
+
+	return l, err
+}

--- a/licenses_test.go
+++ b/licenses_test.go
@@ -1,0 +1,31 @@
+package packagecloud
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) TestClient_Licenses(c *C) {
+	t.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		out := `{
+  "license": "%s",
+  "signature": "testSignature"
+}
+`
+		path := strings.Split(r.URL.Path, "/")
+		w.Write([]byte(fmt.Sprintf(out, path[2])))
+	})
+
+	cl, err := NewClient(t.defaultConfig)
+	c.Assert(err, IsNil)
+
+	var l *License
+
+	l, err = cl.Licenses("testLicense42")
+	c.Assert(err, IsNil)
+	c.Check(l.License, Equals, "testLicense42")
+	c.Check(l.Signature, Equals, "testSignature")
+}

--- a/packagecloud.go
+++ b/packagecloud.go
@@ -3,29 +3,40 @@ package packagecloud
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
+
+	"github.com/hashicorp/cleanhttp"
 )
 
 // Version is WISOTT.
 const Version = "0.0.1"
 
+const baseURL = "https://packagecloud.io/api/v1/"
+
 // Client is the type for the PackageCloud API client. It has functio methods
 // for interacting with the PackageCloud API.
 type Client struct {
-	token string
+	cfg    *Config
+	client *http.Client
 }
 
 // Config is the type for the PackageCloud client configuration.
 type Config struct {
 	// API Token for use with the PackageCloud API
 	Token string
+
+	// BaseURL is the base URL for the API if this is left empty it defaults
+	// to "https://packagecloud.io/api/v1/"
+	BaseURL string
 }
 
 func (c *Client) String() string {
 	var token string
 
-	if len(c.token) > 0 {
-		token = fmt.Sprintf("%s...%s", c.token[0:3], c.token[len(c.token)-4:])
+	if len(c.cfg.Token) > 0 {
+		token = fmt.Sprintf("%s...%s", c.cfg.Token[0:3], c.cfg.Token[len(c.cfg.Token)-4:])
 	}
 
 	return fmt.Sprintf(
@@ -49,9 +60,36 @@ func NewClient(cfg *Config) (*Client, error) {
 		}
 	}
 
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = baseURL
+	}
+
 	c := &Client{
-		token: cfg.Token,
+		cfg:    cfg,
+		client: cleanhttp.DefaultClient(),
 	}
 
 	return c, nil
+}
+
+func (c *Client) request(method, path string) ([]byte, error) {
+	url := fmt.Sprintf("%s%s", c.cfg.BaseURL, path)
+
+	req, err := http.NewRequest(method, url, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(c.cfg.Token, "")
+
+	resp, err := c.client.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	return ioutil.ReadAll(resp.Body)
 }

--- a/packagecloud_test.go
+++ b/packagecloud_test.go
@@ -1,14 +1,27 @@
 package packagecloud
 
 import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 )
 
 type TestSuite struct {
-	token string
+	token         string
+	defaultConfig *Config
+
+	server   *http.Server
+	listener net.Listener
+	mux      *http.ServeMux
+	addr     string
+	url      string
 }
 
 var _ = Suite(&TestSuite{})
@@ -16,7 +29,37 @@ var _ = Suite(&TestSuite{})
 func Test(t *testing.T) { TestingT(t) }
 
 func (t *TestSuite) SetUpSuite(c *C) {
+	t.addr = "127.0.0.1:18982"
+	t.url = fmt.Sprintf("http://%s/", t.addr)
+
 	t.token = "abc123token"
+	t.defaultConfig = &Config{
+		Token:   t.token,
+		BaseURL: t.url,
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:18982")
+	c.Assert(err, IsNil)
+
+	t.listener = listener
+
+	t.server = &http.Server{
+		Addr:         t.addr,
+		ReadTimeout:  time.Second * 20,
+		WriteTimeout: time.Second * 20,
+		ErrorLog:     log.New(ioutil.Discard, "", 0), // disable logging in HTTP server
+	}
+
+	go t.server.Serve(t.listener)
+}
+
+func (t *TestSuite) SetUpTest(c *C) {
+	t.mux = http.NewServeMux()
+	t.server.Handler = t.mux
+}
+
+func (t *TestSuite) TearDownSuite(c *C) {
+	t.listener.Close()
 }
 
 func (t *TestSuite) TearDownTest(c *C) {
@@ -41,7 +84,7 @@ func (t *TestSuite) TestNewClient(c *C) {
 	cl, err = NewClient(&Config{Token: t.token})
 	c.Assert(cl, Not(IsNil))
 	c.Check(err, IsNil)
-	c.Check(cl.token, Equals, "abc123token")
+	c.Check(cl.cfg.Token, Equals, "abc123token")
 
 	//
 	// test that setting a PACKAGECLOUD_TOKEN environment variable works
@@ -50,7 +93,7 @@ func (t *TestSuite) TestNewClient(c *C) {
 	cl, err = NewClient(nil)
 	c.Assert(cl, Not(IsNil))
 	c.Check(err, IsNil)
-	c.Check(cl.token, Equals, "abc123token")
+	c.Check(cl.cfg.Token, Equals, "abc123token")
 }
 
 func (t *TestSuite) TestString(c *C) {
@@ -63,4 +106,17 @@ func (t *TestSuite) TestString(c *C) {
 	cl, err = NewClient(&Config{Token: t.token})
 	c.Assert(err, IsNil)
 	c.Check(cl.String(), Equals, "[*packagecloud.Client:<token:abc...oken>]")
+}
+
+func (t *TestSuite) TestClient_request(c *C) {
+	t.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+
+	cl, err := NewClient(t.defaultConfig)
+	c.Assert(err, IsNil)
+
+	b, err := cl.request("GET", t.url)
+	c.Assert(err, IsNil)
+	c.Check(string(b), Equals, "ok")
 }


### PR DESCRIPTION
This function allows you to retreive a packagecloud:enterprise license file and GPG signature. You can use this to do you own verification.