### PR TITLE
add ability to obtain all package versions for a single package

### DIFF
--- a/packagecloud.go
+++ b/packagecloud.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/hashicorp/cleanhttp"
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 // Version is WISOTT.

--- a/packages.go
+++ b/packages.go
@@ -1,0 +1,80 @@
+package packagecloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PackageVersion is a struct containing version information about packagecloud
+// packages.
+type PackageVersion struct {
+	CreatedAt         *time.Time `json:"created_at"`
+	DistroVersion     string     `json:"distro_version"`
+	Epoch             float64    `json:"epoch"`
+	Filename          string     `json:"filename"`
+	Name              string     `json:"name"`
+	PackageHTMLURL    string     `json:"package_html_url"`
+	PackageURL        string     `json:"package_url"`
+	Private           bool       `json:"private"`
+	Release           string     `json:"release"`
+	RepositoryHTMLURL string     `json:"repository_html_url"`
+	Type              string     `json:"type"`
+	UploaderName      string     `json:"uploader_name"`
+	Version           string     `json:"version"`
+}
+
+func (pv *PackageVersion) String() string {
+	return fmt.Sprintf(
+		"<package: %s [distro: %s|version: %s|release: %s|private: %t]>",
+		pv.Name, pv.DistroVersion, pv.Version, pv.Release, pv.Private,
+	)
+}
+
+// Package is a struct to be passed in to certain *packagecloud.Client functions
+// to specify which location to use.
+type Package struct {
+	User    string // the user this repoistory belongs to
+	Repo    string // the name of the repository
+	Type    string // the type of package it is (e.g., "deb" or "rpm")
+	Distro  string // the name of the distribution the package is in (e.g., "ubuntu")
+	Version string // the version of the distro the package is in (e.g., trusty)
+	Package string // the name of the package
+	Arch    string // the architecture of the package; deb 64-bit: "amd64"; rpm 64-bit: "x86_64"
+}
+
+// PackageVersions is a slice of individual Package Version structs.
+type PackageVersions []*PackageVersion
+
+func (pvs PackageVersions) String() string {
+	var pckgs []string
+
+	for _, p := range pvs {
+		pckgs = append(pckgs, p.String())
+	}
+
+	return fmt.Sprintf("[ %s ]", strings.Join(pckgs, ", "))
+}
+
+// Versions returns the package versions for a specific package. You must
+// specify a package to be retrieved.
+func (c *Client) Versions(r *Package) (PackageVersions, error) {
+	path := fmt.Sprintf(
+		"repos/%s/%s/package/%s/%s/%s/%s/%s/versions.json",
+		r.User, r.Repo, r.Type, r.Distro,
+		r.Version, r.Package, r.Arch,
+	)
+
+	b, err := c.request("GET", path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	pvs := make(PackageVersions, 0)
+
+	err = json.Unmarshal(b, &pvs)
+
+	return pvs, err
+}

--- a/packages_test.go
+++ b/packages_test.go
@@ -1,0 +1,133 @@
+package packagecloud
+
+import (
+	"net/http"
+
+	. "gopkg.in/check.v1"
+)
+
+const packageVersionsOutput = `[
+  {
+    "name": "testPackage",
+    "distro_version": "ubuntu/trusty",
+    "created_at": "2015-11-16T03:39:15.000Z",
+    "version": "0.0.1",
+    "release": "1",
+    "epoch": 0,
+    "private": false,
+    "type": "deb",
+    "filename": "testPackage_0.0.1-1_amd64.deb",
+    "uploader_name": "pagerduty",
+    "repository_html_url": "/pagerduty/test_repo",
+    "package_url": "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.1-1.json",
+    "package_html_url": "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.1-1_amd64.deb"
+  },
+  {
+    "name": "testPackage",
+    "distro_version": "ubuntu/trusty",
+    "created_at": "2015-12-04T16:18:40.000Z",
+    "version": "0.0.2",
+    "release": "1",
+    "epoch": 0,
+    "private": true,
+    "type": "deb",
+    "filename": "testPackage_0.0.2-1_amd64.deb",
+    "uploader_name": "pagerduty",
+    "repository_html_url": "/pagerduty/test_repo",
+    "package_url": "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.2-1.json",
+    "package_html_url": "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.2-1_amd64.deb"
+  },
+  {
+    "name": "testPackage",
+    "distro_version": "ubuntu/trusty",
+    "created_at": "2015-12-10T00:59:42.000Z",
+    "version": "0.0.2",
+    "release": "2",
+    "epoch": 0,
+    "private": true,
+    "type": "deb",
+    "filename": "testPackage_0.0.2-2_amd64.deb",
+    "uploader_name": "pagerduty",
+    "repository_html_url": "/pagerduty/test_repo",
+    "package_url": "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.2-2.json",
+    "package_html_url": "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.2-2_amd64.deb"
+  }
+]`
+
+func (t *TestSuite) TestClient_Versions(c *C) {
+	t.mux.HandleFunc("/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/versions.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(packageVersionsOutput))
+	})
+
+	cl, err := NewClient(t.defaultConfig)
+	c.Assert(err, IsNil)
+
+	var pvs PackageVersions
+
+	r := &Package{
+		User:    "pagerduty",
+		Repo:    "test_repo",
+		Type:    "deb",
+		Distro:  "ubuntu",
+		Version: "trusty",
+		Package: "testPackage",
+		Arch:    "amd64",
+	}
+
+	pvs, err = cl.Versions(r)
+	c.Assert(err, IsNil)
+	c.Assert(len(pvs), Equals, 3)
+
+	var p *PackageVersion
+
+	c.Assert(pvs[0], Not(IsNil))
+	p = pvs[0]
+
+	c.Check(p.CreatedAt.String(), Equals, "2015-11-16 03:39:15 +0000 UTC")
+	c.Check(p.DistroVersion, Equals, "ubuntu/trusty")
+	c.Check(p.Epoch, Equals, 0.0)
+	c.Check(p.Filename, Equals, "testPackage_0.0.1-1_amd64.deb")
+	c.Check(p.Name, Equals, "testPackage")
+	c.Check(p.PackageHTMLURL, Equals, "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.1-1_amd64.deb")
+	c.Check(p.PackageURL, Equals, "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.1-1.json")
+	c.Check(p.Private, Equals, false)
+	c.Check(p.Release, Equals, "1")
+	c.Check(p.RepositoryHTMLURL, Equals, "/pagerduty/test_repo")
+	c.Check(p.Type, Equals, "deb")
+	c.Check(p.UploaderName, Equals, "pagerduty")
+	c.Check(p.Version, Equals, "0.0.1")
+
+	c.Assert(pvs[1], Not(IsNil))
+	p = pvs[1]
+
+	c.Check(p.CreatedAt.String(), Equals, "2015-12-04 16:18:40 +0000 UTC")
+	c.Check(p.DistroVersion, Equals, "ubuntu/trusty")
+	c.Check(p.Epoch, Equals, 0.0)
+	c.Check(p.Filename, Equals, "testPackage_0.0.2-1_amd64.deb")
+	c.Check(p.Name, Equals, "testPackage")
+	c.Check(p.PackageHTMLURL, Equals, "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.2-1_amd64.deb")
+	c.Check(p.PackageURL, Equals, "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.2-1.json")
+	c.Check(p.Private, Equals, true)
+	c.Check(p.Release, Equals, "1")
+	c.Check(p.RepositoryHTMLURL, Equals, "/pagerduty/test_repo")
+	c.Check(p.Type, Equals, "deb")
+	c.Check(p.UploaderName, Equals, "pagerduty")
+	c.Check(p.Version, Equals, "0.0.2")
+
+	c.Assert(pvs[2], Not(IsNil))
+	p = pvs[2]
+
+	c.Check(p.CreatedAt.String(), Equals, "2015-12-10 00:59:42 +0000 UTC")
+	c.Check(p.DistroVersion, Equals, "ubuntu/trusty")
+	c.Check(p.Epoch, Equals, 0.0)
+	c.Check(p.Filename, Equals, "testPackage_0.0.2-2_amd64.deb")
+	c.Check(p.Name, Equals, "testPackage")
+	c.Check(p.PackageHTMLURL, Equals, "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.2-2_amd64.deb")
+	c.Check(p.PackageURL, Equals, "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.2-2.json")
+	c.Check(p.Private, Equals, true)
+	c.Check(p.Release, Equals, "2")
+	c.Check(p.RepositoryHTMLURL, Equals, "/pagerduty/test_repo")
+	c.Check(p.Type, Equals, "deb")
+	c.Check(p.UploaderName, Equals, "pagerduty")
+	c.Check(p.Version, Equals, "0.0.2")
+}


### PR DESCRIPTION
This adds the code required to list all packages versions for a single package. You can use this to programmatically determine the release number.

This also switches to the new path for the Hashicorp `cleanhttp` package.