### PR TITLE
add packagecloudext package for helper functions that use the API

### DIFF
--- a/ext/packagecloudext.go
+++ b/ext/packagecloudext.go
@@ -1,0 +1,49 @@
+package packagecloudext
+
+import (
+	"strconv"
+
+	"github.com/theckman/go-packagecloud"
+)
+
+// NextDebRelease is a helper function for getting the next release version
+// of a Debian package. The idea is to allow your build system to call this
+// function to dynamically pick a release number based on what's uploaded to
+// packagecloud.
+//
+// You need to provide a *packagecloud.Client and a *packagecloud.Package
+// struct to configure which package you are looking at. You must also specify
+// a version string as releases are scoped to versions (i.e., 0.0.1-1, 0.0.1-2, etc.).
+func NextDebRelease(client *packagecloud.Client, pkg *packagecloud.Package, packageVersion string) (int64, error) {
+	pvs, err := client.Versions(pkg)
+
+	if err != nil {
+		return 1, err
+	}
+
+	var rel int64
+
+	// loop over the returned package versions
+	for _, version := range pvs {
+		// if this isn't the right version,
+		// move on to the next PackageVersion
+		if version.Version != packageVersion {
+			continue
+		}
+
+		// convert the value to an int64
+		// ignore an error here and assume the value is 0
+		vRel, _ := strconv.ParseInt(version.Release, 10, 64)
+
+		// if the release version is larger than the biggest release
+		// version seen so far let's swap them
+		if vRel > rel {
+			rel = vRel
+		}
+	}
+
+	// increment the release number to get the next release number
+	rel++
+
+	return rel, nil
+}

--- a/ext/packagecloudext_test.go
+++ b/ext/packagecloudext_test.go
@@ -1,0 +1,97 @@
+package packagecloudext
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/theckman/go-packagecloud"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct {
+	token         string
+	defaultConfig *packagecloud.Config
+
+	server   *http.Server
+	listener net.Listener
+	mux      *http.ServeMux
+	addr     string
+	url      string
+}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) SetUpSuite(c *C) {
+	t.addr = "127.0.0.1:18983"
+	t.url = fmt.Sprintf("http://%s/", t.addr)
+
+	t.token = "abc123token"
+	t.defaultConfig = &packagecloud.Config{
+		Token:   t.token,
+		BaseURL: t.url,
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:18983")
+	c.Assert(err, IsNil)
+
+	t.listener = listener
+
+	t.server = &http.Server{
+		Addr:         t.addr,
+		ReadTimeout:  time.Second * 20,
+		WriteTimeout: time.Second * 20,
+		ErrorLog:     log.New(ioutil.Discard, "", 0), // disable logging in HTTP server
+	}
+
+	go t.server.Serve(t.listener)
+}
+
+func (t *TestSuite) SetUpTest(c *C) {
+	t.mux = http.NewServeMux()
+	t.server.Handler = t.mux
+}
+
+func (t *TestSuite) TearDownSuite(c *C) {
+	t.listener.Close()
+}
+
+func (t *TestSuite) Test_NextDebRelease(c *C) {
+	t.mux.HandleFunc("/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/versions.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(packageVersionsOutput))
+	})
+
+	cl, err := packagecloud.NewClient(t.defaultConfig)
+	c.Assert(err, IsNil)
+
+	var release int64
+
+	r := &packagecloud.Package{
+		User:    "pagerduty",
+		Repo:    "test_repo",
+		Type:    "deb",
+		Distro:  "ubuntu",
+		Version: "trusty",
+		Package: "testPackage",
+		Arch:    "amd64",
+	}
+
+	release, err = NextDebRelease(cl, r, "0.0.1")
+	c.Assert(err, IsNil)
+	c.Check(release, Equals, int64(2))
+
+	release, err = NextDebRelease(cl, r, "0.0.2")
+	c.Assert(err, IsNil)
+	c.Check(release, Equals, int64(3))
+
+	release, err = NextDebRelease(cl, r, "0.0.3")
+	c.Assert(err, IsNil)
+	c.Check(release, Equals, int64(1))
+}

--- a/ext/test_constants_test.go
+++ b/ext/test_constants_test.go
@@ -1,0 +1,49 @@
+package packagecloudext
+
+const packageVersionsOutput = `[
+  {
+    "name": "testPackage",
+    "distro_version": "ubuntu/trusty",
+    "created_at": "2015-11-16T03:39:15.000Z",
+    "version": "0.0.1",
+    "release": "1",
+    "epoch": 0,
+    "private": false,
+    "type": "deb",
+    "filename": "testPackage_0.0.1-1_amd64.deb",
+    "uploader_name": "pagerduty",
+    "repository_html_url": "/pagerduty/test_repo",
+    "package_url": "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.1-1.json",
+    "package_html_url": "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.1-1_amd64.deb"
+  },
+  {
+    "name": "testPackage",
+    "distro_version": "ubuntu/trusty",
+    "created_at": "2015-12-04T16:18:40.000Z",
+    "version": "0.0.2",
+    "release": "1",
+    "epoch": 0,
+    "private": true,
+    "type": "deb",
+    "filename": "testPackage_0.0.2-1_amd64.deb",
+    "uploader_name": "pagerduty",
+    "repository_html_url": "/pagerduty/test_repo",
+    "package_url": "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.2-1.json",
+    "package_html_url": "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.2-1_amd64.deb"
+  },
+  {
+    "name": "testPackage",
+    "distro_version": "ubuntu/trusty",
+    "created_at": "2015-12-10T00:59:42.000Z",
+    "version": "0.0.2",
+    "release": "2",
+    "epoch": 0,
+    "private": true,
+    "type": "deb",
+    "filename": "testPackage_0.0.2-2_amd64.deb",
+    "uploader_name": "pagerduty",
+    "repository_html_url": "/pagerduty/test_repo",
+    "package_url": "/api/v1/repos/pagerduty/test_repo/package/deb/ubuntu/trusty/testPackage/amd64/0.0.2-2.json",
+    "package_html_url": "/pagerduty/test_repo/packages/ubuntu/trusty/testPackage_0.0.2-2_amd64.deb"
+  }
+]`


### PR DESCRIPTION
This adds the `packagecloudext` package which includes helper functions based on functionality within the main `packagecloud` package. The first function is `NextDebRelease` which looks at the versions for a specific package and determines which release number should be next.

For example, assume you have package `testPackage` with the following versions:

```
0.0.1-1
0.0.2-1
0.0.2-2
```

If you were to get the next release number for `0.0.1`, it would be `2`. If you wanted the next release number for `0.0.2`, it would be `3`. Lastly, if you wanted the next release number for `0.0.3`, it would be `1`.
